### PR TITLE
Update h1 to product cost finder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,7 +213,7 @@ export default function TrueCostAI() {
   return (
     <div className="min-h-screen w-full flex flex-col p-4 gap-4 bg-white pb-20">
       <header className="w-full flex flex-col sm:flex-row sm:justify-between items-start sm:items-center">
-        <h1 className="text-xl sm:text-2xl font-bold">TrueCost AI 💸</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">Product cost finder</h1>
         <p className="text-xs sm:text-sm text-gray-500 mt-1 sm:mt-0">Exposing the real cost of your faves</p>
       </header>
 


### PR DESCRIPTION
Update the main heading from 'TrueCost AI 💸' to 'Product cost finder'.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ce7e224-fee5-4ddf-beab-aac92dc9fdce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ce7e224-fee5-4ddf-beab-aac92dc9fdce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

